### PR TITLE
Adapt conformance URLs  to simplified endpoint structure (/testruns)

### DIFF
--- a/apps/api/src/common/EnvVars.ts
+++ b/apps/api/src/common/EnvVars.ts
@@ -42,17 +42,7 @@ const values = {
   Frontend: {
     Url: process.env.FRONTEND_URL ?? "http://localhost:5173",
   },
-  ConformanceApi: {
-    RunTestCasesUrl: `${getEnvVarDefaultOrThrow(
-      "CONFORMANCE_API"
-    )}/runTestCases`,
-    RecentTestRunsUrl: `${getEnvVarDefaultOrThrow(
-      "CONFORMANCE_API"
-    )}/getRecentTestRuns`,
-    TestResultsUrl: `${getEnvVarDefaultOrThrow(
-      "CONFORMANCE_API"
-    )}/getTestResults`,
-  },
+  ConformanceApi: getEnvVarDefaultOrThrow("CONFORMANCE_API")
 };
 
 // Function to get environment variable or throw an error if not se

--- a/apps/api/src/routes/ProxyRoutes.ts
+++ b/apps/api/src/routes/ProxyRoutes.ts
@@ -52,7 +52,7 @@ async function runTestCases(req: IReq, res: IRes) {
       audience?: string;
     };
 
-    const response = await fetch(EnvVars.ConformanceApi.RunTestCasesUrl, {
+    const response = await fetch(`${EnvVars.ConformanceApi}/testruns`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -94,8 +94,7 @@ async function getTestResults(req: IReq, res: IRes) {
   }
 
   try {
-    const url = new URL(EnvVars.ConformanceApi.TestResultsUrl);
-    url.searchParams.append("testRunId", testRunId as string);
+    const url = new URL(`${EnvVars.ConformanceApi}/testruns/${testRunId as string}`);
 
     const response = await fetch(url.toString(), {
       method: "GET",
@@ -131,7 +130,7 @@ async function getRecentTestRuns(req: IReq, res: IRes) {
       return;
     }
 
-    const url = new URL(EnvVars.ConformanceApi.RecentTestRunsUrl);
+    const url = new URL(`${EnvVars.ConformanceApi}/testruns`);
     if (user.role !== "administrator") {
       url.searchParams.append("adminEmail", user.email);
     }


### PR DESCRIPTION
Updates how the API routes interact with the Conformance API by simplifying the environment variable configuration and updating endpoint URLs to match a new structure. 

All conformance calls now go to `${ConformanceApi}/testruns`. 
 - POST /tesruns:  run tests (aka create a testrun)
 - GET /testruns: list recent testruns
 - GET /testruns/:id get testrun details

