### PR TITLE
Fix an issue where the close panel button overlaps the status label

### DIFF
--- a/apps/directory-portal/src/pages/ConformanceTestResult.tsx
+++ b/apps/directory-portal/src/pages/ConformanceTestResult.tsx
@@ -502,6 +502,7 @@ const ConformanceTestResult: React.FC = () => {
                     style={{
                       display: "flex",
                       alignItems: "center",
+                      flexDirection: "column",
                       gap: "8px",
                     }}
                   >


### PR DESCRIPTION
<img width="800" height="682" alt="image" src="https://github.com/user-attachments/assets/ddc31570-ee0b-4caa-a132-7b7ce88a57ef" />
