### PR TITLE
fix: remove check on length of search term

### DIFF
--- a/apps/directory-portal/src/pages/ConformanceTestRuns.tsx
+++ b/apps/directory-portal/src/pages/ConformanceTestRuns.tsx
@@ -80,7 +80,7 @@ const ConformanceTestRuns: React.FC = () => {
         if (val.length === 0) {
           // clear search -> show all
           setSearchParams({}, { replace: true });
-        } else if (val.length > 3) {
+        } else {
           setSearchParams({ q: val }, { replace: true });
         }
         break;


### PR DESCRIPTION
If you enter a search term < 4 characters, the UI doesn't do anything, but also does not give any hint why. 

We can just remove checking the minimum length of the term, for example I would expect to be able to search for CO2 (company name CO2 AI) or SAP, or O2.
